### PR TITLE
ftdetect: handle neomutt filenames, simplification

### DIFF
--- a/ftdetect/muttaliases.vim
+++ b/ftdetect/muttaliases.vim
@@ -1,6 +1,6 @@
 " only enable auto completion in Mutt mails
 " only setup muttrc file after command-line parameters have been processed
-autocmd BufRead,BufNewFile,BufFilePost mutt{ng,}-*-\w\+,mutt[[:alnum:]_-]\\\{6\},neomutt-[[:alnum:]_-]\\\{6\}
+autocmd BufRead,BufNewFile,BufFilePost {neo}mutt{ng,}-*-\w\+,{neo}mutt[[:alnum:]_-]\\\{6\}
       \ exe 'setlocal completefunc=muttaliases#CompleteMuttAliases' |
       \ exe 'command! -buffer EditAliases call muttaliases#EditMuttAliasesFile()' |
       \ autocmd BufWinEnter <buffer> call muttaliases#SetMuttAliasesFile()


### PR DESCRIPTION
* neomutt files in the format such as the following:

        neomutt-hostname-1000-584483-11107844336798908217

  should be handled. Hence, why `{neo}` is prepended to the first regular expression.
* The alternative format for mutt and neomutt should be merged together by prepending `{neo}` to the first regular expression for mutt.
